### PR TITLE
Fix session management and implement guest access

### DIFF
--- a/cmd/lms/main.go
+++ b/cmd/lms/main.go
@@ -34,6 +34,9 @@ func (app *Application) Routes() http.Handler {
 
 	// Public routes
 	mux.Group(func(r chi.Router) {
+		r.Get("/", app.handlers.Dashboard)
+		r.Get("/courses/{courseID}", app.handlers.ShowCourse)
+		r.Get("/lessons/{lessonID}", app.handlers.ShowLesson)
 		r.Get("/register", app.handlers.RegisterForm)
 		r.Post("/register", app.handlers.Register)
 		r.Get("/login", app.handlers.LoginForm)
@@ -50,9 +53,6 @@ func (app *Application) Routes() http.Handler {
 	mux.Group(func(r chi.Router) {
 		r.Use(app.middleware.RequireAuthentication)
 
-		r.Get("/", app.handlers.Dashboard)
-		r.Get("/courses/{courseID}", app.handlers.ShowCourse)
-		r.Get("/lessons/{lessonID}", app.handlers.ShowLesson)
 		r.Post("/mcqs/{mcqID}/submit", app.handlers.SubmitMCQ)
 		r.Post("/lessons/{lessonID}/complete", app.handlers.MarkLessonComplete)
 	})

--- a/migrations/006_create_sessions_table.up.sql
+++ b/migrations/006_create_sessions_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE sessions (
+    token TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    expiry REAL NOT NULL
+);
+
+CREATE INDEX sessions_expiry_idx ON sessions(expiry);

--- a/web/templates/components/_guest_nav.tmpl
+++ b/web/templates/components/_guest_nav.tmpl
@@ -1,0 +1,14 @@
+{{define "guest_nav"}}
+<nav class="bg-white shadow-md">
+    <div class="container mx-auto px-4">
+        <div class="flex justify-between items-center py-4">
+            <a href="/" class="text-xl font-bold text-blue">Training</a>
+            <div>
+                <a href="/" class="text-gray-600 hover:text-blue mr-4">Courses</a>
+                <a href="/login" class="btn btn-outline-blue mr-2">Login</a>
+                <a href="/register" class="btn btn-blue">Register</a>
+            </div>
+        </div>
+    </div>
+</nav>
+{{end}}

--- a/web/templates/components/_nav.tmpl
+++ b/web/templates/components/_nav.tmpl
@@ -3,6 +3,7 @@
         {{template "admin_nav" .}}
     {{else if .IsAuthenticated}}
         {{template "student_nav" .}}
+    {{else}}
+        {{template "guest_nav" .}}
     {{end}}
-    <!-- If not authenticated, this will render nothing, which is correct for login/register pages -->
 {{end}}

--- a/web/templates/course_detail.page.tmpl
+++ b/web/templates/course_detail.page.tmpl
@@ -18,8 +18,10 @@
             {{range .Data.Lessons}}
                 <li class="mt-2">
                     <a href="/lessons/{{.ID}}" class="text-orange">{{.Title}}</a>
-                    {{if (index $.Data.CompletedLessons .ID)}}
-                        <span class="text-sm font-bold text-green-500 ml-2">(Completed)</span>
+                    {{if .IsAuthenticated}}
+                        {{if (index $.Data.CompletedLessons .ID)}}
+                            <span class="text-sm font-bold text-green-500 ml-2">(Completed)</span>
+                        {{end}}
                     {{end}}
                 </li>
             {{end}}

--- a/web/templates/dashboard.page.tmpl
+++ b/web/templates/dashboard.page.tmpl
@@ -7,7 +7,11 @@
 {{end}}
 
 {{define "main"}}
-    <h1 class="text-2xl font-bold text-blue">My Courses</h1>
+    {{if .IsAuthenticated}}
+        <h1 class="text-2xl font-bold text-blue">My Courses</h1>
+    {{else}}
+        <h1 class="text-2xl font-bold text-blue">Available Courses</h1>
+    {{end}}
 
     {{if .Data.Courses}}
         <div class="mt-4">
@@ -22,6 +26,10 @@
             {{end}}
         </div>
     {{else}}
-        <p class="mt-4">You are not enrolled in any courses yet.</p>
+        {{if .IsAuthenticated}}
+            <p class="mt-4">You are not enrolled in any courses yet.</p>
+        {{else}}
+            <p class="mt-4">There are no courses available at the moment. Please check back later.</p>
+        {{end}}
     {{end}}
 {{end}}

--- a/web/templates/lesson_detail.page.tmpl
+++ b/web/templates/lesson_detail.page.tmpl
@@ -1,61 +1,67 @@
 {{template "base" .}}
 
-{{define "title"}}Lesson{{end}}
+{{define "title"}}{{.Data.Lesson.Title}}{{end}}
 
 {{define "nav"}}
     {{template "nav" .}}
 {{end}}
 
 {{define "main"}}
-    <h1 class="text-2xl font-bold text-blue">Lesson Details</h1>
+    <h1 class="text-2xl font-bold text-blue">{{.Data.Lesson.Title}}</h1>
 
-    {{if .Data.Video}}
+    {{if .IsAuthenticated}}
+        {{if .Data.Video}}
+            <div class="card mt-4">
+                <h2 class="text-xl font-bold">{{.Data.Video.Title}}</h2>
+                <div class="mt-4">
+                    <!-- In a real app, you'd embed a video player here -->
+                    <p>Video URL: <a href="{{.Data.Video.VideoURL}}" target="_blank" class="text-orange">{{.Data.Video.VideoURL}}</a></p>
+                </div>
+            </div>
+        {{end}}
+
+        {{if .Data.Text}}
+            <div class="card mt-4">
+                <h2 class="text-xl font-bold">{{.Data.Text.Title}}</h2>
+                <article class="mt-4 prose">
+                    {{.Data.Text.Content}}
+                </article>
+            </div>
+        {{end}}
+
+        {{if .Data.MCQ}}
+            <div class="card mt-4">
+                <h2 class="text-xl font-bold">Quiz</h2>
+                <p class="mt-2">{{.Data.MCQ.Question}}</p>
+                <form action="/mcqs/{{.Data.MCQ.ID}}/submit" method="post" class="mt-4">
+                    {{range $i, $option := .Data.MCQ.Options}}
+                        <div class="mt-2">
+                            <input type="radio" id="option{{$i}}" name="option" value="{{$i}}">
+                            <label for="option{{$i}}" class="ml-2">{{$option}}</label>
+                        </div>
+                    {{end}}
+                    <div class="mt-4">
+                        <button type="submit" class="btn btn-blue">Submit Answer</button>
+                    </div>
+                </form>
+            </div>
+        {{end}}
+
         <div class="card mt-4">
-            <h2 class="text-xl font-bold">{{.Data.Video.Title}}</h2>
-            <div class="mt-4">
-                <!-- In a real app, you'd embed a video player here -->
-                <p>Video URL: <a href="{{.Data.Video.VideoURL}}" target="_blank" class="text-orange">{{.Data.Video.VideoURL}}</a></p>
+            <h2 class="text-xl font-bold">Complete Lesson</h2>
+            <div id="completion-form-{{.Data.Lesson.ID}}">
+                {{if .Data.IsComplete}}
+                    <div class="text-green-500 font-bold mt-2">✓ Completed</div>
+                {{else}}
+                    <form hx-post="/lessons/{{.Data.Lesson.ID}}/complete" hx-target="#completion-form-{{.Data.Lesson.ID}}" hx-swap="innerHTML">
+                        <button type="submit" class="btn btn-orange mt-2">Mark as Complete</button>
+                    </form>
+                {{end}}
             </div>
         </div>
-    {{end}}
-
-    {{if .Data.Text}}
-        <div class="card mt-4">
-            <h2 class="text-xl font-bold">{{.Data.Text.Title}}</h2>
-            <article class="mt-4 prose">
-                {{.Data.Text.Content}}
-            </article>
+    {{else}}
+        <div class="card mt-8">
+            <p>Please <a href="/login" class="text-orange">log in</a> or <a href="/register" class="text-orange">register</a> to view the lesson content.</p>
         </div>
     {{end}}
-
-    {{if .Data.MCQ}}
-        <div class="card mt-4">
-            <h2 class="text-xl font-bold">Quiz</h2>
-            <p class="mt-2">{{.Data.MCQ.Question}}</p>
-            <form action="/mcqs/{{.Data.MCQ.ID}}/submit" method="post" class="mt-4">
-                {{range $i, $option := .Data.MCQ.Options}}
-                    <div class="mt-2">
-                        <input type="radio" id="option{{$i}}" name="option" value="{{$i}}">
-                        <label for="option{{$i}}" class="ml-2">{{$option}}</label>
-                    </div>
-                {{end}}
-                <div class="mt-4">
-                    <button type="submit" class="btn btn-blue">Submit Answer</button>
-                </div>
-            </form>
-        </div>
-    {{end}}
-
-    <div class="card mt-4">
-        <h2 class="text-xl font-bold">Complete Lesson</h2>
-        <div id="completion-form-{{.Data.LessonID}}">
-            {{if .Data.IsComplete}}
-                <div class="text-green-500 font-bold mt-2">✓ Completed</div>
-            {{else}}
-                <form hx-post="/lessons/{{.Data.LessonID}}/complete" hx-target="#completion-form-{{.Data.LessonID}}" hx-swap="innerHTML">
-                    <button type="submit" class="btn btn-orange mt-2">Mark as Complete</button>
-                </form>
-            {{end}}
-        </div>
-    </div>
 {{end}}


### PR DESCRIPTION
This commit addresses two issues:

1.  **Fixes the 'no such table: sessions' error.** A new database migration is added to create the `sessions` table required by the `alexedwards/scs` session management library.

2.  **Implements guest user access to course content.** Guests can now view a list of all available courses and lessons. However, they cannot view the actual lesson content (videos, text, and quizzes) until they log in.

Changes include:
- Added a database migration for the `sessions` table.
- Modified routing to make course and lesson pages public.
- Updated handlers to conditionally load data based on authentication status.
- Adjusted templates to render different content for guests and authenticated users, including a new navigation bar for guests.